### PR TITLE
#63 Fix bad GHA job trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Sphinx
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   sphinx-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes issue where GHA job is set to trigger on the wrong branch name.

Closes #63